### PR TITLE
Update readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,15 @@
 # Bower for Meteor
 
 [Bower](http://bower.io/) is a popular repository of client-side JavaScript
-librairies. In your `smart.json` you can specify a dictionnary of bower packages:
+libraries. In your `smart.json` you can specify a dictionary of bower packages:
 
 ```json
 {
   "meteor": { ... },
-  "packages": { ... },
+  "packages": {
+    ...,
+    bower: {}
+  },
   "bower": {
     "select2": "3.4.5",
     "backbone": "1.1.0"
@@ -14,7 +17,7 @@ librairies. In your `smart.json` you can specify a dictionnary of bower packages
 }
 ```
 
-You now have `select2` and `backbone` librairies in your client application!
+You now have `select2` and `backbone` libraries in your client application!
 
 > To ensure that other people running your app will always get the exact same
 dependencies you must always provide a version number.
@@ -22,11 +25,11 @@ dependencies you must always provide a version number.
 If you don't want to use the `smart.json` file for that purpose, you can use a
 dedicated file named `bower.json`.
 
-## Contribute
+## Contributing
 
 Contributions are very welcome, whether it is for a
 [bug report](https://github.com/mquandalle/meteor-bower/issues/new), a fix or a
-new functionnality proposition.
+new functionality proposition.
 
 ## License
 


### PR DESCRIPTION
Fixed some minor grammar hiccups, without actually changing the formulations.

Made the `smart.json` example clearer because that actually got me stuck for a while; I made a new application, added the package and then added dependencies under `smart.packages.bower` instead of `smart.bower`. Needless to say, it did nothing, and left me scratching my head for a while.
