### PR TITLE
make Super Awesome Magic very obvious in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,9 +54,9 @@ dedicated file named `bower.json`.
 
 # Referring to Bower downloaded assets
 
-Bower for Meteor automatically adds the appropriate HTML tags to include your Bower packages. In our example above we can *just start using* `select2` in our we can just start using `select2` widgets and styles will be set correctly.
+Bower for Meteor automatically adds the appropriate HTML tags to include your Bower packages. In our example above we can *just start using* `select2` widgets and styles will be set correctly.
 
-Just look at the HTML Source of a rendered page if you don't believe me!
+If you're curious just look at the HTML source of a rendered page!
 
 Compare this to Bower out of the box, where you need to either manually reference the included files or use something like [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install) to reference them. 
 


### PR DESCRIPTION
It wasn't obvious how to reference Bower included files. Now it's obvious (Super Awesome Magic!)
