### PR TITLE
support structure of bower.json

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -158,5 +158,15 @@ Plugin.registerSourceHandler("bower.json", function (compileStep) {
 
   var bowerTree = loadJSONFile(compileStep);
 
-  return bowerHandler(compileStep, bowerTree);
+  var realTree;
+
+  // bower.json files have additional metadata beyond what we care about (dependancies)
+  // but previous versions of this package assumed it was a flatter list
+  // so allow both
+  if (_.has(bowerTree, "dependencies"))
+  	realTree = bowerTree.dependencies;
+  else
+  	realTree = bowerTree;
+
+  return bowerHandler(compileStep, realTree);
 });


### PR DESCRIPTION
bower.json top level keys may include name, version and other keys we don't care about. We really only care about the dependency key. So limit our search to that, if it's there. Else bower-meteor will throw errors like "expected 'name' to have a version string", which of course it won't.

Let me know if there's anything I can do to clean this PR up for acceptance, or if I missed something (I'm new to writing Meteor plugins but I think I understand this plugin enough to be confident about my change, unless I'm misreading the code somewhat.)
