### PR TITLE
Use force latest so build doesn't break on unresolvable version conflicts

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -52,7 +52,7 @@ var bowerHandler = function (compileStep, bowerTree) {
 
   // Installation
   if (installList.length) {
-    var installedPackages = Bower.install(installList, {save: true}, {directory: bowerDirectory});
+    var installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
     _.each(installedPackages, function (val, pkgName) {
       log(pkgName + " v" + val.pkgMeta.version + " successfully installed");
     });


### PR DESCRIPTION
Open to discussing this - but I had to fork and use this per two packages I use thinking they require two different versions of another packages but actually don't (this has been a frequent problem for me with bower in general, hence I happily use the force latest option for everything). 

Currently there is no other workaround and so without this if you have a version conflict (that is actually benign) your meteor app will never build again :(