### PR TITLE
Overrides support

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -10,7 +10,7 @@ log = function (message) {
   return console.log("Bower: ", message);
 };
 
-var bowerHandler = function (compileStep, bowerTree) {
+var bowerHandler = function (compileStep, bowerTree, originalTree) {
 
   if (! _.isObject(bowerTree))
     compileStep.error({
@@ -66,6 +66,11 @@ var bowerHandler = function (compileStep, bowerTree) {
   _.each(bowerTree, function (options, pkgName) {
     var bowerInfosPath = path.join(bowerDirectory, pkgName, '.bower.json');
     var infos = loadJSONContent(compileStep, fs.readFileSync(bowerInfosPath));
+
+    // Bower overrides support
+    if (originalTree.overrides && originalTree.overrides[pkgName]) {
+      _.extend(infos, originalTree.overrides[pkgName]);
+    }
 
     if (! _.has(infos, "main") && ! options.additionalFiles)
       return;
@@ -172,6 +177,7 @@ Plugin.registerSourceHandler("json", null);
 
 Plugin.registerSourceHandler("bower.json", {archMatching: "web"}, function (compileStep) {
   var bowerTree = loadJSONFile(compileStep);
+  var originalTree = bowerTree;
 
   // bower.json files have additional metadata beyond what we care about (dependancies)
   // but previous versions of this package assumed it was a flatter list
@@ -179,5 +185,5 @@ Plugin.registerSourceHandler("bower.json", {archMatching: "web"}, function (comp
   if (_.has(bowerTree, "dependencies"))
     bowerTree = bowerTree.dependencies;
 
-  return bowerHandler(compileStep, bowerTree);
+  return bowerHandler(compileStep, bowerTree, originalTree);
 });


### PR DESCRIPTION
Some packages don't use the main property, so similar projects (e.g. [wiredep](https://github.com/taptapship/wiredep)) allow an "overrides" property to override such as - 

Unless there is another way to do this that I am not aware :)

Open to feedback on if there is any other way you'd prefer this implemented

Happy Valentines day

```json
{
  "name": "Chat",
  "dependencies": {
    "jquery": "~2.1.3",
    "lodash": "~3.1.0",
    "modernizr": "~2.8.3",
    "angularjs-toaster": "~0.4.10",
    "angular-hotkeys": "chieffancypants/angular-hotkeys#~1.4.5",
    "underscore.string": "~3.0.3",
    "ace-builds": "~1.1.8",
    "angular-ui-ace": "~0.2.3"
  },
  "overrides": {
    "ace-builds": {
      "main": [
        "src-noconflict/ace.js",
        "src-noconflict/mode-coffee.js",
        "src-noconflict/theme-tomorrow_night_eighties.js"
      ]
    }
  }
}
```