### PR TITLE
Installs packages from cache

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -43,18 +43,22 @@ var bowerHandler = function (compileStep, bowerTree, originalTree) {
   //  Ref: https://github.com/bower/bower.json-spec#dependencies
   var installList = _.map(bowerTree, mapBowerDefinitions);
 
-  // `localCache` use the same format than `installList`:
-  // ["foo#1.2.3", "foo#2.1.2"]
-  // If a value is present in `localCache` we remove it from the `installList`
-  var localCache = Bower.list(null, {offline: true, directory: bowerDirectory});
-  localCache = _.map(localCache.pkgMeta.dependencies, mapBowerDefinitions);
-  installList = _.filter(installList, function (pkg) {
-    return localCache.indexOf(pkg) === -1;
-  });
-
   // Installation
   if (installList.length) {
-    var installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
+    var installedPackages = [];
+    // Try to install packages offline first.
+    try {
+      installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory, offline: true});
+    }
+    catch( e ) {
+      // In case of failure, try to fetch packages online
+      try {
+        installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
+      }
+      catch( e ) {
+        log( e );
+      }
+    }
     _.each(installedPackages, function (val, pkgName) {
        log(pkgName + " v" + val.pkgMeta.version + " successfully installed");
     });

--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -48,12 +48,13 @@ var bowerHandler = function (compileStep, bowerTree, originalTree) {
     var installedPackages = [];
     // Try to install packages offline first.
     try {
-      installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory, offline: true});
+      installedPackages = Bower.install([], {save: true, forceLatest: true}, {directory: bowerDirectory, offline: true});
     }
     catch( e ) {
+      log( e );
       // In case of failure, try to fetch packages online
       try {
-        installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
+        installedPackages = Bower.install([], {save: true, forceLatest: true}, {directory: bowerDirectory});
       }
       catch( e ) {
         log( e );


### PR DESCRIPTION
Fixes #56. There is still an issue with this solution. Application won't start if you are offline and bower cache was cleared. It doesn't matter if all packages are already installed in the application folder, bower seems to need its cache to check if everything is ok. 
The only way I found to fix this is to take the list of dependencies from `bower.list` function (same as issuing a `bower list -o -json` on the cli) and recursively go through all dependencies and check for missing ones. If no one is missing, then you are ok to go and there is no need to download packages from the internet.