### PR TITLE
Multi install location fix

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -154,13 +154,6 @@ var parseJSONFile = function(file) {
   return null;
 };
 
-//
-// Parse ./.bowerrc file if exists in the project's root folder.
-//
-var bowerrc = parseJSONFile('./.bowerrc');
-if (bowerrc && _.has(bowerrc, "directory"))
-  bowerHome = bowerrc.directory;
-
 /*******************/
 /* Source Handlers */
 /*******************/

--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -178,7 +178,7 @@ Plugin.registerSourceHandler("bower.json", {archMatching: "web"}, function (comp
   // Install bower components into the local meteor directory.
   // XXX Should we find a better host?
   var bowerHome = ".meteor/local/bower";
-  var bowerrc = parseJSONFile(path.dirname(compileStep.inputPath) + '/.bowerrc');
+  var bowerrc = parseJSONFile(path.dirname(compileStep._fullInputPath) + '/.bowerrc');
   if (bowerrc && _.has(bowerrc, "directory"))
     bowerHome = bowerrc.directory;
 

--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -43,18 +43,22 @@ var bowerHandler = function (compileStep, bowerTree, originalTree) {
   //  Ref: https://github.com/bower/bower.json-spec#dependencies
   var installList = _.map(bowerTree, mapBowerDefinitions);
 
-  // `localCache` use the same format than `installList`:
-  // ["foo#1.2.3", "foo#2.1.2"]
-  // If a value is present in `localCache` we remove it from the `installList`
-  var localCache = Bower.list(null, {offline: true, directory: bowerDirectory});
-  localCache = _.map(localCache.pkgMeta.dependencies, mapBowerDefinitions);
-  installList = _.filter(installList, function (pkg) {
-    return localCache.indexOf(pkg) === -1;
-  });
-
   // Installation
   if (installList.length) {
-    var installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
+    var installedPackages = [];
+    // Try to install packages offline first.
+    try {
+      installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory, offline: true});
+    }
+    catch( e ) {
+      // In case of failure, try to fetch packages online
+      try {
+        installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
+      }
+      catch( e ) {
+        log( e );
+      }
+    }
     _.each(installedPackages, function (val, pkgName) {
        log(pkgName + " v" + val.pkgMeta.version + " successfully installed");
     });

--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -10,7 +10,7 @@ log = function (message) {
   return console.log("Bower: ", message);
 };
 
-var bowerHandler = function (compileStep, bowerTree, originalTree) {
+var bowerHandler = function (compileStep, bowerTree) {
 
   if (! _.isObject(bowerTree.dependencies))
     compileStep.error({
@@ -75,8 +75,8 @@ var bowerHandler = function (compileStep, bowerTree, originalTree) {
     var infos = loadJSONContent(compileStep, fs.readFileSync(bowerInfosPath));
 
     // Bower overrides support
-    if (originalTree.overrides && originalTree.overrides[pkgName]) {
-      _.extend(infos, originalTree.overrides[pkgName]);
+    if (bowerTree.overrides && bowerTree.overrides[pkgName]) {
+      _.extend(infos, bowerTree.overrides[pkgName]);
     }
 
     if (! _.has(infos, "main"))
@@ -177,7 +177,6 @@ Plugin.registerSourceHandler("json", null);
 
 Plugin.registerSourceHandler("bower.json", {archMatching: "web"}, function (compileStep) {
   var bowerTree = loadJSONFile(compileStep);
-  var originalTree = bowerTree;
 
-  return bowerHandler(compileStep, bowerTree, originalTree);
+  return bowerHandler(compileStep, bowerTree);
 });

--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -48,12 +48,13 @@ var bowerHandler = function (compileStep, bowerTree, originalTree) {
     var installedPackages = [];
     // Try to install packages offline first.
     try {
-      installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory, offline: true});
+      installedPackages = Bower.install([], {save: true, forceLatest: true}, {directory: bowerDirectory, offline: true});
     }
     catch( e ) {
+      log( e );
       // In case of failure, try to fetch packages online
       try {
-        installedPackages = Bower.install(installList, {save: true, forceLatest: true}, {directory: bowerDirectory});
+        installedPackages = Bower.install([], {save: true, forceLatest: true}, {directory: bowerDirectory});
       }
       catch( e ) {
         log( e );

--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -2,15 +2,11 @@ var path = Npm.require("path");
 var fs = Npm.require("fs");
 var glob = Npm.require("glob");
 
-// Install bower components into the local meteor directory.
-// XXX Should we find a better host?
-var bowerHome = ".meteor/local/bower";
-
 log = function (message) {
   return console.log("Bower: ", message);
 };
 
-var bowerHandler = function (compileStep, bowerTree) {
+var bowerHandler = function (compileStep, bowerTree, bowerHome) {
 
   if (! _.isObject(bowerTree.dependencies))
     compileStep.error({
@@ -178,5 +174,15 @@ Plugin.registerSourceHandler("json", null);
 Plugin.registerSourceHandler("bower.json", {archMatching: "web"}, function (compileStep) {
   var bowerTree = loadJSONFile(compileStep);
 
-  return bowerHandler(compileStep, bowerTree);
+  //
+  // Parse .bowerrc file if exists in the same folder as bower.json
+  //
+  // Install bower components into the local meteor directory.
+  // XXX Should we find a better host?
+  var bowerHome = ".meteor/local/bower";
+  var bowerrc = parseJSONFile(path.dirname(compileStep.inputPath) + '/.bowerrc');
+  if (bowerrc && _.has(bowerrc, "directory"))
+    bowerHome = bowerrc.directory;
+
+  return bowerHandler(compileStep, bowerTree, bowerHome);
 });


### PR DESCRIPTION
Fixes #49. This modifications allows to have multiple `bower.json` and `.bowerrc` files spread in different folders to be able to install packages to different locations.

For example, create `bower.json` in project root with the following content:
```JSON
{
  "name": "bower-test",
  "version": "0.0.0",
  "authors": [
    "Joth Doe <john.doe@domain.com>"
  ],
  "license": "MIT",
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ],
  "dependencies": {
    "select2": "~3.5.2"
  }
}
```

And a `.bowerrc` file with
```JSON
{
  "directory": "./public/components"
}
```

Then create `lib/bower.json` file
```JSON
{
  "name": "bower-test",
  "version": "0.0.0",
  "authors": [
    "Joth Doe <john.doe@domain.com>"
  ],
  "license": "MIT",
  "ignore": [
    "**/.*",
    "node_modules",
    "bower_components",
    "test",
    "tests"
  ],
  "dependencies": {
    "d3": "~3.5.5"
  }
}
```

and `lib/.bowerrc`:
{
  "directory": "../public/other_components"
}

This will install `select2` in `public/components` and `d3` in `public/other_components` as expected. As `.bowerrc` file is in the same folder as `bower.json`, packages can also be installed using `bower install`.

This can be used to install public bower packages in the public folder, and private bower packages in the default `.meteor/local/bower` location, so they are protected from public access.

Test it and let me know.