### PR TITLE
using pkgMeta.name instead of pkgMeta._originalSource

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -82,6 +82,10 @@ var bowerHandler = function (compileStep, bowerTree, bowerHome) {
   //  good version. Hopefully the `constraint-solver` package will help.
   _.each(bowerDependencies, function (item) {
     var pkgName = item.pkgMeta._originalSource || item.pkgName;
+    if ( pkgName.indexOf( '://' ) !== -1 || pkgName.indexOf( '@' ) !== -1 ) { // it's a url, probably not what we are looking for
+      pkgName = item.pkgMeta.name;
+    }
+
     var pkgPath = path.join(cwd, bowerHome, pkgName);
     var infos = item.pkgMeta;
 


### PR DESCRIPTION
Using _originalSource causes problems with git installed packages.