### PR TITLE
Skip directories when adding files from `"main"` in target packages.

### DIFF
--- a/plugin/handler.js
+++ b/plugin/handler.js
@@ -134,8 +134,16 @@ var bowerHandler = function (compileStep, bowerTree, bowerHome) {
       _.each(toInclude, function (fileName) {
         var contentPath = path.join(pkgPath, fileName);
         var virtualPath = path.join('packages/bower/', pkgName, fileName);
-        var content = fs.readFileSync(contentPath);
-        var ext = path.extname(fileName).slice(1);
+        var content;
+        var ext;
+
+        // Only load real files
+        if (!fs.lstatSync(contentPath).isFile()) {
+          return;
+        }
+
+        content = fs.readFileSync(contentPath);
+        ext = path.extname(fileName).slice(1);
 
         // XXX It would be cool to be able to add a ressource and let Meteor use
         // the right source handler.


### PR DESCRIPTION
Not sure if this is the best solution — maybe it should recurse directories instead of just skipping them?

Came across this when trying to use meteor-bower with [Materialize](https://github.com/Dogfalo/materialize), which specifies `"sass/*"` in `"main"` in its [bower.json](https://github.com/Dogfalo/materialize/blob/master/bower.json#L39).

This threw an error when building, which I found was because [handler.js:L137](https://github.com/mquandalle/meteor-bower/blob/master/plugin/handler.js#L137) was trying to call `fs.readFileSync()` on `"/path/to/.meteor/local/bower/materialize/sass/components"`, which is a directory:

```
$ meteor
...
=> Errors prevented startup:

   While building the application:
   fs.js:488:19: EISDIR, illegal operation on a directory (compiling lib/bower/bower.json)
   at Object.fs.readSync (fs.js:488:19)
   at Object.<anonymous>
   (/path/to/.meteor/packages/meteor-tool/.1.1.9.1sd3e7j++os.osx.x86_64+web.browser+web.cordova/mt-os.osx.x86_64/dev_bundle/lib/node_modules/cordova-lib/node_modules/npm/node_modules/graceful-fs/polyfills.js:110:28)
   at Object.fs.readSync
   (/path/to/.meteor/packages/mquandalle_bower/.1.5.2.kqfmpv++os+web.browser+web.cordova/plugin.bower.os/npm/bower/node_modules/bower/node_modules/bower-config/node_modules/graceful-fs/polyfills.js:218:23)
   at Object.fs.readSync
   (/path/to/.meteor/packages/mquandalle_bower/.1.5.2.kqfmpv++os+web.browser+web.cordova/plugin.bower.os/npm/bower/node_modules/bower/node_modules/bower-registry-client/node_modules/graceful-fs/polyfills.js:218:23)
   at Object.fs.readSync
   (/path/to/.meteor/packages/mquandalle_bower/.1.5.2.kqfmpv++os+web.browser+web.cordova/plugin.bower.os/npm/bower/node_modules/bower/node_modules/bower-json/node_modules/graceful-fs/polyfills.js:218:23)
   at Object.fs.readFileSync (fs.js:322:28)
   at packages/bower/plugin/handler.js:137:1
   at Array.forEach (native)
   at Function._.each._.forEach (packages/underscore/underscore.js:105:1)
   at packages/bower/plugin/handler.js:134:1
   at Array.forEach (native)
   at Function._.each._.forEach (packages/underscore/underscore.js:105:1)
   at bowerHandler (packages/bower/plugin/handler.js:94:1)
   at Package (packages/bower/plugin/handler.js:254:1)
```